### PR TITLE
fix: correctly split crv, handle missing styles/prop/breakpoints

### DIFF
--- a/apps/vite-react/package-lock.json
+++ b/apps/vite-react/package-lock.json
@@ -52,11 +52,11 @@
         "@pandacss/types": "0.37.2",
         "@playwright/test": "1.43.1",
         "@types/node": "20.12.7",
-        "@vitest/coverage-v8": "1.4.0",
+        "@vitest/coverage-v8": "1.5.0",
         "prettier": "3.2.5",
         "tsup": "8.0.2",
         "typescript": "5.4.5",
-        "vitest": "1.4.0"
+        "vitest": "1.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/__tests__/codegen.test.ts
+++ b/src/__tests__/codegen.test.ts
@@ -30,6 +30,8 @@ describe('codegen', () => {
               "code": "
       const crvBreakpoints = ['sm', 'md', 'lg', 'xl', 'xxl'];
       export const crv = (name, styles) => {
+        if (!name) return;
+
         const variants = {
           [name]: styles,
         };
@@ -58,6 +60,7 @@ describe('codegen', () => {
         let variants = { [name]: base };
 
         for (const bp of crvBreakpoints) {
+          if (!(bp in rest)) continue;
           variants[\`\${name}_\${bp}\`] = rest[bp];
         }
 
@@ -71,11 +74,26 @@ describe('codegen', () => {
 
       type CrvBreakpoints = 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
+      /**
+       * Create responsive variants
+       *
+       * @example
+       * cva({
+       *  variants: {
+       *    ...crv('prop', {
+       *      variant1: { color: 'red' },
+       *      variant2: { color: 'blue' }
+       *    })
+       * })
+       */
       export declare const crv: <T extends string, P extends Record<any, SystemStyleObject>>(
         name: T,
         styles: P
       ) => Record<\`\${T}_\${CrvBreakpoints}\` | T, P>;
 
+      /**
+       * Splits responsive objects into \`crv\` variants
+       */
       export declare const splitCrv: <T extends string>(
         name: T,
         value: any

--- a/src/__tests__/crv.test.ts
+++ b/src/__tests__/crv.test.ts
@@ -1,0 +1,286 @@
+import { crv, crvFunc } from '../crv';
+import { breakpoints } from './fixtures';
+
+const { splitCrv, crv: crvCodegen } = await import(
+  `data:text/javascript,${crvFunc(Object.keys(breakpoints))}`
+);
+
+describe('crv', () => {
+  it('returns the expected variants', () => {
+    const result = crv(
+      'prop',
+      { variant1: { color: 'red' }, variant2: { color: 'blue' } },
+      Object.keys(breakpoints),
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": {
+          "variant1": {
+            "color": "red",
+          },
+          "variant2": {
+            "color": "blue",
+          },
+        },
+        "prop_lg": {
+          "variant1": {
+            "lg": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "lg": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_md": {
+          "variant1": {
+            "md": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "md": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_sm": {
+          "variant1": {
+            "sm": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "sm": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_xl": {
+          "variant1": {
+            "xl": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "xl": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_xxl": {
+          "variant1": {
+            "xxl": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "xxl": {
+              "color": "blue",
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('handles no breakpoints', () => {
+    const result = crv(
+      'prop',
+      { true: { color: 'red' }, false: { color: 'blue' } },
+      [],
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": {
+          "false": {
+            "color": "blue",
+          },
+          "true": {
+            "color": "red",
+          },
+        },
+      }
+    `);
+  });
+
+  it('handles no variants', () => {
+    const result = crv('prop', {}, Object.keys(breakpoints));
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": {},
+        "prop_lg": {},
+        "prop_md": {},
+        "prop_sm": {},
+        "prop_xl": {},
+        "prop_xxl": {},
+      }
+    `);
+  });
+
+  it('handles no prop', () => {
+    const result = crv('', {}, Object.keys(breakpoints));
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('crv codegen', () => {
+  it('returns the expected variants', () => {
+    const result = crvCodegen('prop', {
+      variant1: { color: 'red' },
+      variant2: { color: 'blue' },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": {
+          "variant1": {
+            "color": "red",
+          },
+          "variant2": {
+            "color": "blue",
+          },
+        },
+        "prop_lg": {
+          "variant1": {
+            "lg": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "lg": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_md": {
+          "variant1": {
+            "md": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "md": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_sm": {
+          "variant1": {
+            "sm": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "sm": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_xl": {
+          "variant1": {
+            "xl": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "xl": {
+              "color": "blue",
+            },
+          },
+        },
+        "prop_xxl": {
+          "variant1": {
+            "xxl": {
+              "color": "red",
+            },
+          },
+          "variant2": {
+            "xxl": {
+              "color": "blue",
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('handles no variants', () => {
+    const result = crvCodegen('prop', {});
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": {},
+        "prop_lg": {},
+        "prop_md": {},
+        "prop_sm": {},
+        "prop_xl": {},
+        "prop_xxl": {},
+      }
+    `);
+  });
+
+  it('handles no prop', () => {
+    const result = crvCodegen('', {});
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('splitCrv codegen', () => {
+  it('handles non-reponsive values', async () => {
+    expect(splitCrv('prop', 'variant')).toEqual({ prop: 'variant' });
+    expect(splitCrv('prop', false)).toEqual({ prop: false });
+  });
+
+  it('splits the crv', async () => {
+    const result = splitCrv('prop', {
+      base: 'variant1',
+      sm: 'variant2',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": "variant1",
+        "prop_sm": "variant2",
+      }
+    `);
+  });
+
+  it('handles invalid prop keys', async () => {
+    const result = splitCrv('prop', {
+      base: 'variant1',
+      notMe: 'variant2',
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": "variant1",
+      }
+    `);
+  });
+
+  it('handles falsey values', async () => {
+    const result = splitCrv('prop', {
+      base: null,
+      lg: false,
+      md: '',
+      xl: undefined,
+      xxl: 0,
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "prop": null,
+        "prop_lg": false,
+        "prop_md": "",
+        "prop_xl": undefined,
+        "prop_xxl": 0,
+      }
+    `);
+  });
+});

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -45,76 +45,7 @@ describe('parser', () => {
               // background: crv('nope'),
             },
             variants: {
-              ...{
-                  "tone": {
-                    "negative": {
-                      "bg": "red.200"
-                    },
-                    "positive": {
-                      "bg": "green.200"
-                    }
-                  },
-                  "tone_sm": {
-                    "negative": {
-                      "sm": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "sm": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_md": {
-                    "negative": {
-                      "md": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "md": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_lg": {
-                    "negative": {
-                      "lg": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "lg": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_xl": {
-                    "negative": {
-                      "xl": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "xl": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_xxl": {
-                    "negative": {
-                      "xxl": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "xxl": {
-                        "bg": "green.200"
-                      }
-                    }
-                  }
-                },
+              ...{"tone":{"negative":{"bg":"red.200"},"positive":{"bg":"green.200"}},"tone_sm":{"negative":{"sm":{"bg":"red.200"}},"positive":{"sm":{"bg":"green.200"}}},"tone_md":{"negative":{"md":{"bg":"red.200"}},"positive":{"md":{"bg":"green.200"}}},"tone_lg":{"negative":{"lg":{"bg":"red.200"}},"positive":{"lg":{"bg":"green.200"}}},"tone_xl":{"negative":{"xl":{"bg":"red.200"}},"positive":{"xl":{"bg":"green.200"}}},"tone_xxl":{"negative":{"xxl":{"bg":"red.200"}},"positive":{"xxl":{"bg":"green.200"}}}},
             },
           });
 
@@ -154,76 +85,7 @@ describe('parser', () => {
               // background: crv('nope'),
             },
             variants: {
-              ...{
-                  "visible": {
-                    "true": {
-                      "opacity": 1
-                    },
-                    "false": {
-                      "opacity": 0
-                    }
-                  },
-                  "visible_sm": {
-                    "true": {
-                      "sm": {
-                        "opacity": 1
-                      }
-                    },
-                    "false": {
-                      "sm": {
-                        "opacity": 0
-                      }
-                    }
-                  },
-                  "visible_md": {
-                    "true": {
-                      "md": {
-                        "opacity": 1
-                      }
-                    },
-                    "false": {
-                      "md": {
-                        "opacity": 0
-                      }
-                    }
-                  },
-                  "visible_lg": {
-                    "true": {
-                      "lg": {
-                        "opacity": 1
-                      }
-                    },
-                    "false": {
-                      "lg": {
-                        "opacity": 0
-                      }
-                    }
-                  },
-                  "visible_xl": {
-                    "true": {
-                      "xl": {
-                        "opacity": 1
-                      }
-                    },
-                    "false": {
-                      "xl": {
-                        "opacity": 0
-                      }
-                    }
-                  },
-                  "visible_xxl": {
-                    "true": {
-                      "xxl": {
-                        "opacity": 1
-                      }
-                    },
-                    "false": {
-                      "xxl": {
-                        "opacity": 0
-                      }
-                    }
-                  }
-                },
+              ...{"visible":{"true":{"opacity":1},"false":{"opacity":0}},"visible_sm":{"true":{"sm":{"opacity":1}},"false":{"sm":{"opacity":0}}},"visible_md":{"true":{"md":{"opacity":1}},"false":{"md":{"opacity":0}}},"visible_lg":{"true":{"lg":{"opacity":1}},"false":{"lg":{"opacity":0}}},"visible_xl":{"true":{"xl":{"opacity":1}},"false":{"xl":{"opacity":0}}},"visible_xxl":{"true":{"xxl":{"opacity":1}},"false":{"xxl":{"opacity":0}}}},
             },
           });
           "
@@ -257,104 +119,7 @@ describe('parser', () => {
               // background: crv('size', { foo: { bg: 'red'}}),
             },
             variants: {
-              ...{
-                  "tone": {
-                    "neutral": {
-                      "bg": "gray.200"
-                    },
-                    "negative": {
-                      "bg": "red.200"
-                    },
-                    "positive": {
-                      "bg": "green.200"
-                    }
-                  },
-                  "tone_sm": {
-                    "neutral": {
-                      "sm": {
-                        "bg": "gray.200"
-                      }
-                    },
-                    "negative": {
-                      "sm": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "sm": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_md": {
-                    "neutral": {
-                      "md": {
-                        "bg": "gray.200"
-                      }
-                    },
-                    "negative": {
-                      "md": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "md": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_lg": {
-                    "neutral": {
-                      "lg": {
-                        "bg": "gray.200"
-                      }
-                    },
-                    "negative": {
-                      "lg": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "lg": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_xl": {
-                    "neutral": {
-                      "xl": {
-                        "bg": "gray.200"
-                      }
-                    },
-                    "negative": {
-                      "xl": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "xl": {
-                        "bg": "green.200"
-                      }
-                    }
-                  },
-                  "tone_xxl": {
-                    "neutral": {
-                      "xxl": {
-                        "bg": "gray.200"
-                      }
-                    },
-                    "negative": {
-                      "xxl": {
-                        "bg": "red.200"
-                      }
-                    },
-                    "positive": {
-                      "xxl": {
-                        "bg": "green.200"
-                      }
-                    }
-                  }
-                },
+              ...{"tone":{"neutral":{"bg":"gray.200"},"negative":{"bg":"red.200"},"positive":{"bg":"green.200"}},"tone_sm":{"neutral":{"sm":{"bg":"gray.200"}},"negative":{"sm":{"bg":"red.200"}},"positive":{"sm":{"bg":"green.200"}}},"tone_md":{"neutral":{"md":{"bg":"gray.200"}},"negative":{"md":{"bg":"red.200"}},"positive":{"md":{"bg":"green.200"}}},"tone_lg":{"neutral":{"lg":{"bg":"gray.200"}},"negative":{"lg":{"bg":"red.200"}},"positive":{"lg":{"bg":"green.200"}}},"tone_xl":{"neutral":{"xl":{"bg":"gray.200"}},"negative":{"xl":{"bg":"red.200"}},"positive":{"xl":{"bg":"green.200"}}},"tone_xxl":{"neutral":{"xxl":{"bg":"gray.200"}},"negative":{"xxl":{"bg":"red.200"}},"positive":{"xxl":{"bg":"green.200"}}}},
             }
           });
           "
@@ -383,21 +148,14 @@ describe('parser', () => {
               // background: crv('size', { foo: { bg: 'red' }}),
             },
             variants: {
-              ...{
-                  "tone": {},
-                  "tone_sm": {},
-                  "tone_md": {},
-                  "tone_lg": {},
-                  "tone_xl": {},
-                  "tone_xxl": {}
-                },
+              ...{"tone":{},"tone_sm":{},"tone_md":{},"tone_lg":{},"tone_xl":{},"tone_xxl":{}},
             }
           });
           "
     `);
   });
 
-  it('skips without ct imports or expressions', () => {
+  it('skips without crv imports or expressions', () => {
     expect(
       makeParser(`<div className={css({ bg: crv("test", {}) })/>`),
     ).toBeUndefined();
@@ -405,5 +163,28 @@ describe('parser', () => {
     expect(
       makeParser(`import { crv } from '@/styled-system/css`),
     ).toBeUndefined();
+  });
+
+  it('skips without crv return value', () => {
+    expect(
+      makeParser(`
+        import { crv, cva } from '@/styled-system/css';
+
+        const styles = cva({
+          variants: {
+            ...crv('', {}),
+          }
+        });
+      `),
+    ).toMatchInlineSnapshot(`
+      "import { crv, cva } from '@/styled-system/css';
+
+              const styles = cva({
+                variants: {
+                  ...crv('', {}),
+                }
+              });
+            "
+    `);
   });
 });

--- a/src/crv.ts
+++ b/src/crv.ts
@@ -3,6 +3,8 @@ export const crv = <T extends string, P extends Record<any, any>>(
   styles: P,
   breakpoints: string[],
 ) => {
+  if (!name) return;
+
   const variants = {
     [name]: styles,
   } as Record<T | `${T}_${(typeof breakpoints)[number]}`, any>;
@@ -25,6 +27,8 @@ export const crv = <T extends string, P extends Record<any, any>>(
 export const crvFunc = (breakpoints: string[]) => `
 const crvBreakpoints = [${breakpoints.map((bp) => `'${bp}'`).join(', ')}];
 export const crv = (name, styles) => {
+  if (!name) return;
+
   const variants = {
     [name]: styles,
   };
@@ -53,6 +57,7 @@ export const splitCrv = (name, value) => {
   let variants = { [name]: base };
 
   for (const bp of crvBreakpoints) {
+    if (!(bp in rest)) continue;
     variants[\`\${name}_\${bp}\`] = rest[bp];
   }
 
@@ -64,11 +69,26 @@ import type { SystemStyleObject } from '../types/system-types';
 
 type CrvBreakpoints = ${breakpoints.map((bp) => `'${bp}'`).join(' | ')};
 
+/**
+ * Create responsive variants
+ *
+ * @example
+ * cva({
+ *  variants: {
+ *    ...crv('prop', {
+ *      variant1: { color: 'red' },
+ *      variant2: { color: 'blue' }
+ *    })
+ * })
+ */
 export declare const crv: <T extends string, P extends Record<any, SystemStyleObject>>(
   name: T,
   styles: P
 ) => Record<\`\${T}_\${CrvBreakpoints}\` | T, P>;
 
+/**
+ * Splits responsive objects into \`crv\` variants
+ */
 export declare const splitCrv: <T extends string>(
   name: T,
   value: any

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -38,7 +38,9 @@ export const parser = (
     const prop = node.getArguments()[0]?.getText().replace(/['"]/g, '');
     const styles = node.getArguments()[1]?.getText() ?? '{}';
     const value = crv(prop, json5.parse(styles), context.breakpoints);
-    node.replaceWithText(JSON.stringify(value, null, 2));
+
+    if (!value) continue;
+    node.replaceWithText(JSON.stringify(value));
   }
 
   context.debug?.(


### PR DESCRIPTION
- `splitCrv` correctly passes through valid variants, excluding unknown keys
- Adds js doc descriptions to codegen'ed functions
- Adds better tests for codegen'ed functions and edge cases