### PR TITLE
feat(ccv)!: use Panda compound variant syntax in ccv args

### DIFF
--- a/apps/vite-react/src/app.tsx
+++ b/apps/vite-react/src/app.tsx
@@ -39,18 +39,24 @@ const recipe = cva({
     }),
   },
   compoundVariants: [
-    ...ccv(
-      { variant1: 'bar', variant2: 'foo' },
-      { borderRadius: '10px', margin: ct('margin.sm') },
-    ),
-    ...ccv(
-      { variant1: 'foo', variant2: 'bar' },
-      { color: 'red.600', margin: ct('margin.sm') },
-    ),
-    ...ccv(
-      { variant1: 'foo', variant2: 'baz' },
-      { bg: 'indigo.500', color: 'gray.100', margin: 0 },
-    ),
+    ...ccv({
+      variant1: 'bar',
+      variant2: 'foo',
+      css: {
+        borderRadius: '10px',
+        margin: ct('margin.sm'),
+      },
+    }),
+    ...ccv({
+      variant1: 'foo',
+      variant2: 'bar',
+      css: { color: 'red.600', margin: ct('margin.sm') },
+    }),
+    ...ccv({
+      variant1: 'foo',
+      variant2: 'baz',
+      css: { bg: 'indigo.500', color: 'gray.100', margin: 0 },
+    }),
   ],
 });
 

--- a/src/__tests__/ccv.test.ts
+++ b/src/__tests__/ccv.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 fs.writeFileSync('_test-ccvFunc.mts', crvFunc(Object.keys(breakpoints)));
 
 const {
-  ccv: ccvCodegen,
+  ccv,
   // @ts-ignore
 } = await import('_test-ccvFunc.mts');
 
@@ -15,13 +15,11 @@ describe('crv codegen', () => {
   });
 
   it('returns the expected variants', () => {
-    const result = ccvCodegen(
-      {
-        variant1: 'red',
-        variant2: 'blue',
-      },
-      { bg: 'green' },
-    );
+    const result = ccv({
+      variant1: 'red',
+      variant2: 'blue',
+      css: { bg: 'green' },
+    });
 
     expect(result).toMatchInlineSnapshot(`
       [
@@ -64,24 +62,16 @@ describe('crv codegen', () => {
   });
 
   it('handles no variants', () => {
-    const result = ccvCodegen(
-      // @ts-ignore
-      null,
-      { bg: 'green' },
-    );
+    const result = ccv({ bg: 'green' });
 
     expect(result).toEqual([]);
   });
 
   it('handles no styles', () => {
-    const result = ccvCodegen(
-      {
-        variant1: 'red',
-        variant2: 'blue',
-      },
-      // @ts-ignore
-      null,
-    );
+    const result = ccv({
+      variant1: 'red',
+      variant2: 'blue',
+    });
     expect(result).toEqual([]);
   });
 });

--- a/src/__tests__/codegen.test.ts
+++ b/src/__tests__/codegen.test.ts
@@ -138,8 +138,6 @@ describe('codegen', () => {
       export type ResponsiveVariant<T> = Partial<Record<'base' | CrvBreakpoints, T>> | T;
 
 
-
-      type 
       /**
        * Create compound variants
        *
@@ -154,9 +152,13 @@ describe('codegen', () => {
        *   })
        * },
        * compoundVariants: [
-       *  ...ccv(
-       *    { variant1: 'red', variant2: 'blue', css: { bg: 'green' }},
-       *   )
+       *  ...ccv({
+       *    variant1: 'red',
+       *    variant2: 'blue',
+       *    css: {
+       *      bg: 'green'
+       *    }
+       *  })
        * ]
        */
       export declare const ccv: <T extends Record<any, any> & { css: SystemStyleObject }>(

--- a/src/__tests__/codegen.test.ts
+++ b/src/__tests__/codegen.test.ts
@@ -86,7 +86,8 @@ describe('codegen', () => {
         return Object.entries(result);
       };
 
-      export const ccv = (variants, css) => {
+      export const ccv = (args) => {
+        const { css, ...variants }  = args;
         if (!variants || !css) return [];
 
         const compoundVariants = [{ ...variants, css }];
@@ -137,6 +138,8 @@ describe('codegen', () => {
       export type ResponsiveVariant<T> = Partial<Record<'base' | CrvBreakpoints, T>> | T;
 
 
+
+      type 
       /**
        * Create compound variants
        *
@@ -152,15 +155,13 @@ describe('codegen', () => {
        * },
        * compoundVariants: [
        *  ...ccv(
-       *    { variant1: 'red', variant2: 'blue' },
-       *    { bg: 'green' }
+       *    { variant1: 'red', variant2: 'blue', css: { bg: 'green' }},
        *   )
        * ]
        */
-      export declare const ccv: <T extends Record<any, any>, P extends SystemStyleObject>(
-        variants: T,
-        css: P
-      ) => Array<{ css: P } & Record<keyof T, any>>;
+      export declare const ccv: <T extends Record<any, any> & { css: SystemStyleObject }>(
+        args: T,
+      ) => Array<{ css: T['css'] } & Record<keyof T, any>>;
 
       ",
               "file": "crv.d.ts",

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -268,8 +268,8 @@ describe('crv parser', () => {
   });
 });
 
-describe('ccv parser', () => {
-  it('parses', () => {
+describe.only('ccv parser', () => {
+  it.only('parses', () => {
     const res = makeParser(`
     import foo from 'bar';
     import { css, cva, ccv } from '@/styled-system/css';
@@ -278,8 +278,9 @@ describe('ccv parser', () => {
       compoundVariants: [
         ...ccv({
           variant1: 'red',
-          variant2: 'blue'
-        }, { bg: 'green' }),
+          variant2: 'blue',
+          css: { bg: 'green' }
+        }),
       ],
     });
     `);
@@ -305,8 +306,9 @@ describe('ccv parser', () => {
       compoundVariants: [
         ...alias({
           variant1: 'red',
-          variant2: 'blue'
-        }, { bg: 'green' }),
+          variant2: 'blue',
+          css: { bg: 'green' }
+        }),
       ],
     });
     `);
@@ -379,9 +381,8 @@ describe('ccv parser', () => {
       compoundVariants: [
         ...ccv({
           variant1: 'red',
-          variant2: 'blue'
-        }, {
-          foo: { bar: { baz: '#fff' }}
+          variant2: 'blue',
+          css: { foo: { bar: { baz: '#fff' }} }
         }),
       ],
     });
@@ -407,9 +408,8 @@ describe('ccv parser', () => {
       compoundVariants: [
         ...ccv({
           variant1: 'red',
-          variant2: 'blue'
-        }, {
-          foo: { '& > *': { "3baz": \`\${'#fff'}\`}}
+          variant2: 'blue',
+          css: { foo: { '& > *': { "3baz": \`\${'#fff'}\`}}}
         }),
       ],
     });
@@ -435,9 +435,8 @@ describe('ccv parser', () => {
         compoundVariants: [
           ...ccv({
             variant1: true,
-            variant2: false
-          }, {
-            foo: { bar: { srOnly: false }}
+            variant2: false,
+            css: { foo: { bar: { srOnly: false }} }
           }),
         ],
       });
@@ -465,9 +464,8 @@ describe('ccv parser', () => {
         compoundVariants: [
           ...ccv({
             variant1: 1,
-            variant2: 0
-          }, {
-            foo: { opacity: 0.5 }
+            variant2: 0,
+            css: { foo: { opacity: 0.5 }}
           }),
         ],
       });
@@ -493,9 +491,8 @@ describe('ccv parser', () => {
         compoundVariants: [
           ...ccv({
             variant1: 1,
-            variant2: 0
-          }, {
-            foo: { opacity: get('test'), bg: \`\${get('test')}\` }
+            variant2: 0,
+            css: { foo: { opacity: get('test'), bg: \`\${get('test')}\` }}
           }),
         ],
       });

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -268,8 +268,8 @@ describe('crv parser', () => {
   });
 });
 
-describe.only('ccv parser', () => {
-  it.only('parses', () => {
+describe('ccv parser', () => {
+  it('parses', () => {
     const res = makeParser(`
     import foo from 'bar';
     import { css, cva, ccv } from '@/styled-system/css';

--- a/src/ccv.ts
+++ b/src/ccv.ts
@@ -12,7 +12,8 @@ const groupByBreakpoint = (variants) => {
   return Object.entries(result);
 };
 
-export const ccv = (variants, css) => {
+export const ccv = (args) => {
+  const { css, ...variants }  = args;
   if (!variants || !css) return [];
 
   const compoundVariants = [{ ...variants, css }];
@@ -25,6 +26,8 @@ export const ccv = (variants, css) => {
 };`;
 
 export const ccvDts = `
+
+type 
 /**
  * Create compound variants
  *
@@ -40,13 +43,11 @@ export const ccvDts = `
  * },
  * compoundVariants: [
  *  ...ccv(
- *    { variant1: 'red', variant2: 'blue' },
- *    { bg: 'green' }
+ *    { variant1: 'red', variant2: 'blue', css: { bg: 'green' }},
  *   )
  * ]
  */
-export declare const ccv: <T extends Record<any, any>, P extends SystemStyleObject>(
-  variants: T,
-  css: P
-) => Array<{ css: P } & Record<keyof T, any>>;
+export declare const ccv: <T extends Record<any, any> & { css: SystemStyleObject }>(
+  args: T,
+) => Array<{ css: T['css'] } & Record<keyof T, any>>;
 `;

--- a/src/ccv.ts
+++ b/src/ccv.ts
@@ -26,8 +26,6 @@ export const ccv = (args) => {
 };`;
 
 export const ccvDts = `
-
-type 
 /**
  * Create compound variants
  *
@@ -42,9 +40,13 @@ type
  *   })
  * },
  * compoundVariants: [
- *  ...ccv(
- *    { variant1: 'red', variant2: 'blue', css: { bg: 'green' }},
- *   )
+ *  ...ccv({
+ *    variant1: 'red',
+ *    variant2: 'blue',
+ *    css: {
+ *      bg: 'green'
+ *    }
+ *  })
  * ]
  */
 export declare const ccv: <T extends Record<any, any> & { css: SystemStyleObject }>(


### PR DESCRIPTION
refactors usage:
```ts
...ccv({
  variant1: 'bar',
  variant2: 'foo',
  css: {
    borderRadius: '10px',
    margin: ct('margin.sm'),
  },
}),
```

before:

```ts
...ccv(
  { variant1: 'bar', variant2: 'foo' },
  { borderRadius: '10px', margin: ct('margin.sm') },
),
```